### PR TITLE
Saved jobs page incorporate cards

### DIFF
--- a/app/controllers/saved_jobs_controller.rb
+++ b/app/controllers/saved_jobs_controller.rb
@@ -23,7 +23,7 @@ class SavedJobsController < ApplicationController
   def destroy
     @saved_job = SavedJob.find(params[:id])
     if @saved_job.destroy
-      redirect_to saved_jobs_path, notice: 'Successfully removed from your saved jobs'
+      redirect_to jobs_path, notice: 'Successfully removed from your saved jobs'
     else
       render saved_jobs_path, status: :unprocessable_entity
     end

--- a/app/controllers/saved_jobs_controller.rb
+++ b/app/controllers/saved_jobs_controller.rb
@@ -16,7 +16,8 @@ class SavedJobsController < ApplicationController
     @job = Job.find(params[:job_id])
     @saved_job.job = @job
     if @saved_job.save
-      redirect_to jobs_path, notice: 'Job successfully saved!'
+      # redirect_to jobs_path, notice: 'Job successfully saved!'
+      redirect_to request.referrer, notice: 'Job successfully saved!'
     else
       redirect_to job_path(@job), alert: 'Something went wrong, please try again'
     end
@@ -25,7 +26,7 @@ class SavedJobsController < ApplicationController
   def destroy
     @saved_job = SavedJob.find(params[:id])
     if @saved_job.destroy
-      redirect_to jobs_path, notice: 'Successfully removed from your saved jobs'
+      redirect_to request.referrer, notice: 'Successfully removed from your saved jobs'
     else
       render saved_jobs_path, status: :unprocessable_entity
     end

--- a/app/controllers/saved_jobs_controller.rb
+++ b/app/controllers/saved_jobs_controller.rb
@@ -1,6 +1,8 @@
 class SavedJobsController < ApplicationController
   def index
     @saved_jobs = SavedJob.where(user_id: current_user.id)
+    @initial_jobs = @saved_jobs.limit(5)
+    @remaining_jobs = @saved_jobs.offset(5)
   end
 
   def new

--- a/app/views/jobs/_row.html.erb
+++ b/app/views/jobs/_row.html.erb
@@ -31,7 +31,10 @@
           </div>
           <div class="col ">
             <% if SavedJob.where(job_id: job.id).present? %>
-              <i class="fa-solid fa-heart saved-job-heart-icon"></i>
+
+              <%= link_to saved_job_path(job.saved_job_ids), data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to remove this job from your list?"} do %>
+                <i class="fa-solid fa-heart saved-job-heart-icon"></i>
+              <% end %>
             <% else %>
               <%= link_to job_saved_jobs_path(job), data: {turbo_method: :post} do %>
                 <i class="fa-regular fa-heart not-saved-job-heart-icon"></i>

--- a/app/views/saved_jobs/index.html.erb
+++ b/app/views/saved_jobs/index.html.erb
@@ -1,39 +1,44 @@
 <div class="container">
+  <%= form_tag apply_jobs_path, method: :post do %>
 
-  <h3 id="saved-jobs-index-title">My Saved Jobs</h3>
-  <div class="row">
-    <div class="col-12">
-      <div class="card job-list-header">
-        <div class="card-body">
-          <div class="row text-center">
-            <div class="col">Company</div>
-            <div class="col">Role</div>
-            <div class="col-2 d-none" data-job-index-toggle-target="newColumn1">Description</div>
-            <div class="col">Salary</div>
-            <div class="col">Status</div>
-            <div class="col">Deadline</div>
-            <div class="col">CV</div>
-            <div class="col">Details</div>
-            <div class="col">Save</div>
-            <div class="col">Select</div>
+    <div class="sticky-top bg-white d-flex align-items-center justify-content-between">
+      <h3 id="saved-jobs-index-title">My Saved Jobs</h3>
+      <div><%= submit_tag "Apply to 0 Jobs", id: "apply-button", "data": {job_index_toggle_target: "applyButton"}, class: "btn btn-apply" %></div>
+    </div>
+
+    <div class="row">
+      <div class="col-12">
+        <div class="card job-list-header">
+          <div class="card-body">
+            <div class="row text-center">
+              <div class="col">Company</div>
+              <div class="col">Role</div>
+              <div class="col-2 d-none" data-job-index-toggle-target="newColumn1">Description</div>
+              <div class="col">Salary</div>
+              <div class="col">Status</div>
+              <div class="col">Deadline</div>
+              <div class="col">CV</div>
+              <div class="col">Details</div>
+              <div class="col">Save</div>
+              <div class="col">Select</div>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="job-cards-container pt-0" data-controller="load-more">
-    <% @initial_jobs.each do |saved_job| %>
-      <%= render 'jobs/row', job: saved_job.job %>
-    <% end %>
-    <div data-load-more-target="remaining" class="d-none">
-      <% @remaining_jobs.each do |saved_job| %>
+    <div class="job-cards-container pt-0" data-controller="load-more">
+      <% @initial_jobs.each do |saved_job| %>
         <%= render 'jobs/row', job: saved_job.job %>
       <% end %>
+      <div data-load-more-target="remaining" class="d-none">
+        <% @remaining_jobs.each do |saved_job| %>
+          <%= render 'jobs/row', job: saved_job.job %>
+        <% end %>
+      </div>
+      <div class="d-flex justify-content-start">
+        <%= link_to "Show More", "#", data: { action: "click->load-more#showMore" }, class: "btn btn-cheddar-secondary", "data-load-more-target": "button" %>
+      </div>
     </div>
-    <div class="d-flex justify-content-start">
-      <%= link_to "Show More", "#", data: { action: "click->load-more#showMore" }, class: "btn btn-cheddar-secondary", "data-load-more-target": "button" %>
-    </div>
-  </div>
-
+  <% end %>
 </div>

--- a/app/views/saved_jobs/index.html.erb
+++ b/app/views/saved_jobs/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" data-controller="styling-selected-job job-index-toggle">
   <%= form_tag apply_jobs_path, method: :post do %>
 
     <div class="sticky-top bg-white d-flex align-items-center justify-content-between">

--- a/app/views/saved_jobs/index.html.erb
+++ b/app/views/saved_jobs/index.html.erb
@@ -1,61 +1,39 @@
 <div class="container">
-  <div class="row">
-    <div class="col-sm-12">
-      <h3 id="saved-jobs-index-title">My Saved Jobs</h3>
 
-        <div class="row mb-4">
-          <div class="col-12">
-            <div class="card job-list-header">
-              <div class="card-body">
-                <div class="row">
-                  <div class="col">Company</div>
-                  <div class="col">Role</div>
-                  <div class="col">Est. Salary</div>
-                  <div class="col">Status</div>
-                  <div class="col">Deadline</div>
-                  <div class="col">CV</div>
-                  <div class="col">Cover Letter</div>
-                  <div class="col">Job Details</div>
-                  <div class="col">Remove</div>
-                </div>
-              </div>
-            </div>
+  <h3 id="saved-jobs-index-title">My Saved Jobs</h3>
+  <div class="row">
+    <div class="col-12">
+      <div class="card job-list-header">
+        <div class="card-body">
+          <div class="row text-center">
+            <div class="col">Company</div>
+            <div class="col">Role</div>
+            <div class="col-2 d-none" data-job-index-toggle-target="newColumn1">Description</div>
+            <div class="col">Salary</div>
+            <div class="col">Status</div>
+            <div class="col">Deadline</div>
+            <div class="col">CV</div>
+            <div class="col">Details</div>
+            <div class="col">Save</div>
+            <div class="col">Select</div>
           </div>
         </div>
-
-        <% @saved_jobs.each do |saved_job| %>
-          <div class="row mb-3">
-            <div class="col-12">
-              <div class="card job-card">
-                <div class="card-body">
-                  <div class="row">
-                    <div class="col"><%= saved_job.job.company.company_name %></div>
-                    <div class="col"><%= link_to saved_job.job.job_title, job_path(saved_job) %></div>
-                    <div class="col">£<%= number_with_delimiter(saved_job.job.salary, :delimiter => ',') %></div>
-                    <div class="col">
-                      <% if (Time.now.next_day(7)) >= saved_job.job.application_deadline %>
-                        CLOSING SOON
-                      <% elsif Time.now < saved_job.job.application_deadline %>
-                        OPEN
-                      <% else %>
-                        CLOSED
-                      <% end %>
-                    </div>
-                    <div class="col"><%= saved_job.job.application_deadline %></div>
-                    <div class="col text-center"><input type="checkbox"></div>
-                    <div class="col text-center"><input type="checkbox"></div>
-                    <div class="col text-center"><a href="https://external-link.com" target="_blank">Details</a></div>
-                    <div class="col text-center">
-                      <%= link_to saved_job_path(saved_job), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to remove this job from your list?"} do %>
-                        <i class="fa-solid fa-trash"></i>
-                      <% end %>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        <% end %>
+      </div>
     </div>
   </div>
+
+  <div class="job-cards-container pt-0" data-controller="load-more">
+    <% @initial_jobs.each do |saved_job| %>
+      <%= render 'jobs/row', job: saved_job.job %>
+    <% end %>
+    <div data-load-more-target="remaining" class="d-none">
+      <% @remaining_jobs.each do |saved_job| %>
+        <%= render 'jobs/row', job: saved_job.job %>
+      <% end %>
+    </div>
+    <div class="d-flex justify-content-start">
+      <%= link_to "Show More", "#", data: { action: "click->load-more#showMore" }, class: "btn btn-cheddar-secondary", "data-load-more-target": "button" %>
+    </div>
+  </div>
+
 </div>


### PR DESCRIPTION
Added: 
- Ability to un-save from heart icon on jobs index page
- Incorporated the cards from jobs index page to saved_jobs index page, including: design, limit (changed to 5), show more button, apply button, javascript styling the selected cards & counting the number of jobs selected
- Ability to apply to several jobs from saved_jobs index page
- Fixed re-directs so save/unsave does not make me loose my filters on the jobs index page & the save/unsave redirects me to the page I was on when I actioned it, regardless of the page. 