### PR TITLE
Clear search button

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -24,25 +24,11 @@
   border: none;
   border-radius: 8px;
   padding: 10px 20px;
-  margin-right: 6px;
+  // margin-right: 6px;
   margin-left: 6px;
 }
 
-.clear-search-button {
-  background-color: rgba(154, 145, 145, 0.454);
-  opacity: 0.8;
-  color: white;
-  // font-weight: 500;
-  text-decoration: none;
-  border: none;
-  border-radius: 8px;
-  padding: 12px 20px;
-}
 
-.clear-search-button:hover {
-  text-decoration: none;
-
-}
 
 .btn-add-info, #btn-add-job {
   background-color: $main-color;

--- a/app/assets/stylesheets/components/_search_bar.scss
+++ b/app/assets/stylesheets/components/_search_bar.scss
@@ -10,6 +10,13 @@
   border-radius: 10px;
 }
 
+.clear-search-icon {
+  color: grey;
+  position: relative;
+  right: 28px;
+  top: 10px;
+}
+
 .search-bar-background {
   background-color: #4c4747c8; /* Replace with your desired color */
   border-radius: 10px; /* Adjust for desired roundness */

--- a/app/views/jobs/_search.html.erb
+++ b/app/views/jobs/_search.html.erb
@@ -6,5 +6,11 @@
         placeholder: 'Search for any job, company or role... ', style: 'font-style: italic;', id: 'search-jobs' %>
     <%= submit_tag 'Search', id: 'search-button' %>
   <% end %>
-  <%= link_to 'Clear', jobs_path, class: 'btn clear-search-button' %>
+
+  <%= link_to jobs_path do %>
+    <i class="fa-solid fa-x"></i>
+  <% end %>
+
+
+  <%# <%= link_to 'Clear', jobs_path, class: 'btn clear-search-button' %>
 </div>

--- a/app/views/jobs/_search.html.erb
+++ b/app/views/jobs/_search.html.erb
@@ -4,13 +4,14 @@
         params[:query],
         class: 'form-control',
         placeholder: 'Search for any job, company or role... ', style: 'font-style: italic;', id: 'search-jobs' %>
+
+    <%= link_to jobs_path, class: 'clear-search-icon' do %>
+      <i class="fa-solid fa-x"></i>
+    <% end %>
+
     <%= submit_tag 'Search', id: 'search-button' %>
   <% end %>
 
-  <%= link_to jobs_path do %>
-    <i class="fa-solid fa-x"></i>
-  <% end %>
 
 
-  <%# <%= link_to 'Clear', jobs_path, class: 'btn clear-search-button' %>
 </div>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -9,7 +9,7 @@
 
         <%# LHS Section - Title and Search  %>
         <div class="d-flex justify-content-between">
-          <h6 id="jobs-index-left-section-title"><%= (@jobs.count - @job_applications.count) %> Jobs</h6>
+          <h6 id="jobs-index-left-section-title"><%= @jobs.count %> Jobs</h6>
         </div>
 
         <%# TODO: Add icons %>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -9,7 +9,14 @@
 
         <%# LHS Section - Title and Search  %>
         <div class="d-flex justify-content-between">
-          <h6 id="jobs-index-left-section-title"><%= @jobs.count %> Jobs</h6>
+          <h6 id="jobs-index-left-section-title">
+            <% if params[:query].present? %>
+              <%= @jobs.count %>
+            <% else %>
+              <%= @jobs.count - @job_applications.count %>
+            <% end %>
+            Jobs
+          </h6>
         </div>
 
         <%# TODO: Add icons %>


### PR DESCRIPTION
Added: 
- Button to clear search on jobs index page has been replaced by an X icon on the right side of the search bar
- Updated the jobs count that appears on the top left corner of the jobs index page so it takes into account when params are passed and it does no longer subtract the number of applications but just returns the number of jobs rendered by the search