### PR TITLE
fixing issue with cookies where we reset the cookies to params each t…

### DIFF
--- a/app/controllers/job_applications_controller.rb
+++ b/app/controllers/job_applications_controller.rb
@@ -40,10 +40,26 @@ class JobApplicationsController < ApplicationController
   def create
     # Retrieve user inputs from the form
 
-    user_input = params[:user_input]
+    # user_input = params[:user_input]
 
     # Process each selected job
-    job = Job.find(params[:job_id])
+
+    if cookies[:job_app_no].to_i > 1
+      job = Job.find(cookies[:selected_job_ids].split("&").first)
+    else
+      job = Job.find(params[:job_id])
+    end
+
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p "&&&&&&&&&&&&&&&&&&&&&&&&"
+    p job
+
+    # job = Job.find(params[:job_id])
 
     # update the job/ application criteria
 
@@ -70,7 +86,7 @@ class JobApplicationsController < ApplicationController
       p ids
       ids.delete("#{job.id}")
       p ids
-      cookies[:selected_job_ids] = ids
+      cookies[:selected_job_ids] = ids.join("&")
 
       # Redirect to the job applications index page or another appropriate page
       redirect_to job_applications_path, notice: 'Your applications have been submitted.'

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -38,13 +38,26 @@ class JobsController < ApplicationController
 
   def apply_to_selected_jobs
     # Fetch the selected job IDs from the parameters
+
+
+    p "---------------------"
+    p "---------------------"
+    p "---------------------"
+    p "---------------------"
+    p "---------------------"
+    p "---------------------"
+    p "---------------------"
+
+    p "Params:"
     p params
     selected_job_ids = params[:job_ids]
-    p cookies[:selected_job_ids]
-    p selected_job_ids
+    cookies[:selected_job_ids]
+    cookies[:job_app_no] ||= 0
+
 
     # Instead of directly creating job applications, store the selected jobs in the session or another temporary store
     cookies[:selected_job_ids] = selected_job_ids
+    cookies[:job_app_no] = cookies[:job_app_no].to_i + 1
     # raise
     # Redirect to a new action that will display the staging page
     redirect_to new_job_application_path

--- a/app/views/job_applications/index.html.erb
+++ b/app/views/job_applications/index.html.erb
@@ -25,9 +25,6 @@
           <% if application.screenshot.attached? %>
             <div class="image-overlay">
               <%= image_tag(cl_image_path application.screenshot.key) %>
-              <div class="overlay-text">
-                <p>No image available - here's a happy doggo instead</p>
-              </div>
             </div>
           <% else %>
             <%= image_tag("job_app_complete_default.jpg") %>


### PR DESCRIPTION
…ime we call ApplyJob. Now setting a new cookie which increments each time we run the ApplyJob. For the first run we use params and then for the subsequent ones we use cookies. Not a great solution as will cause a problem if the user goes through the application process multiple times but a nice patch before demo day tomorrow